### PR TITLE
PyOpenRTMPluginのPythonパスを修正

### DIFF
--- a/src/OpenRTMPlugin/pybind11/CMakeLists.txt
+++ b/src/OpenRTMPlugin/pybind11/CMakeLists.txt
@@ -5,4 +5,4 @@ add_cnoid_python_module(${target}
   PyItems.cpp
 )
 
-target_link_libraries(${target} CnoidOpenRTMPlugin CnoidPyBase C:/Python37/Libs/python37.lib)
+target_link_libraries(${target} CnoidOpenRTMPlugin CnoidPyBase ${CHOREONOID_PYTHON_LIBRARIES})


### PR DESCRIPTION
#### 修正内容

choreonoid-openrtm/src/OpenRTMPlugin/pybind11/CMakeList.txt　でPythonのパスを以下のように修正しました。

target_link_libraries(${target} CnoidOpenRTMPlugin CnoidPyBase ${CHOREONOID_PYTHON_LIBRARIES})